### PR TITLE
Lcov

### DIFF
--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -14,17 +14,15 @@
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     Provider = providers:create([
-                                 {name, ?PROVIDER},
-                                 {namespace, ?NAMESPACE},
-                                 {module, ?MODULE},
-                                 {bare, true},
-                                 {deps, ?DEPS},
-                                 {example, "rebar3 rebar3_codecov"},
-                                 {opts, [
-                                        {path, $p, "path", string, "location of the *.coverdata files"}
-                                        ]},
-                                 {short_desc, ?DESC},
-                                 {desc, ?DESC}
+                                    {name, ?PROVIDER},
+                                    {namespace, ?NAMESPACE},
+                                    {module, ?MODULE},
+                                    {bare, true},
+                                    {deps, ?DEPS},
+                                    {example, "rebar3 codecov"},
+                                    {opts, []},
+                                    {short_desc, ?DESC},
+                                    {desc, ?DESC}
                                 ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -32,13 +30,16 @@ init(State) ->
 do(State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
     Apps = filter_apps(RawOpts, State),
-    lists:map(fun(App) ->  add_profile_ebin_path(App, State),
-                           add_app_ebin_path(App) end, Apps),
+    lists:map(fun(App) ->
+                  add_profile_ebin_path(App, State),
+                  add_app_ebin_path(App)
+              end, Apps),
     AppsInfo = rebar_state:project_apps(State),
-    Defaults = lists:map(fun(App) -> EBin = rebar_app_info:ebin_dir(App),
-                                     rebar_dir:make_relative_path(EBin, rebar_dir:root_dir(State)) end, AppsInfo),
+    Defaults = lists:map(fun(App) ->
+                             EBin = rebar_app_info:ebin_dir(App),
+                             rebar_dir:make_relative_path(EBin, rebar_dir:root_dir(State))
+                         end, AppsInfo),
     code:add_paths(Defaults),
-    rebar_api:info("~nExporting cover data from _build/test/cover...~n", []),
     Files = lists:flatmap(fun get_coverdata_files/1, AppsInfo),
     Data = analyze(Files),
     rebar_api:info("exporting ~s~n", [?OUT_FILE]),
@@ -53,13 +54,17 @@ format_error(Reason) ->
 analyze(Files) ->
     try
         cover:start(),
-        lists:map(fun(F) ->  cover:import(F),
-                             rebar_api:info("importing ~s~n", [F]) end, Files),
+        lists:map(fun(F) ->
+                      cover:import(F),
+                      rebar_api:info("importing ~s~n", [F])
+                  end,
+                  Files),
         Modules = cover:imported_modules(),
         {result, Result, _} = cover:analyse(Modules, calls, line),
         Result
-    catch Error:Reason ->
-              rebar_api:abort("~p~n~p~n~p~n",[Error, Reason, erlang:get_stacktrace()])
+    catch
+        Error:Reason ->
+            rebar_api:abort("~p~n~p~n~p~n",[Error, Reason, erlang:get_stacktrace()])
     end.
 
 to_json(Data) ->
@@ -81,9 +86,10 @@ get_source_path(Module) when is_atom(Module) ->
     Name = atom_to_list(Module)++".erl",
     try filelib:wildcard([filename:join(["src/**/", Name])]) of
         [P] -> P;
-        _ -> Issue = io_lib:format("Failed to calculate the source path of module ~p~n", [Module]),
-             rebar_api:warn("~s~n", [Issue]),
-             []
+        _ ->
+            Issue = io_lib:format("Failed to calculate the source path of module ~p~n", [Module]),
+            rebar_api:warn("~s~n", [Issue]),
+            []
     catch
         Error:Reason ->
             Issue = io_lib:format("Failed to calculate the source path of module ~p~n
@@ -117,11 +123,10 @@ get_coverdata_files(AppInfo) ->
     Opts = rebar_app_info:opts(AppInfo),
     CoverDataPath = case dict:find(codecov_opts, Opts) of
                         {ok, CodecovOpts} ->
-                            case proplists:get_value(path, CodecovOpts, ["_build/test/cover"]) of
-                                undefined -> ["_build/test/cover/*.coverdata"];
-                                Paths ->    lists:map(fun(P) -> filename:join([P, "*.coverdata"]) end, Paths)
-                            end;
+                            Paths = proplists:get_value(path, CodecovOpts, ["_build/test/cover"]),
+                            lists:map(fun(P) -> filename:join([P, "*.coverdata"]) end, Paths);
                         _ ->
                             ["_build/test/cover/*.coverdata"]
                     end,
+    rebar_api:info("Exporting cover data from ~p~n", [CoverDataPath]),
     lists:flatmap(fun filelib:wildcard/1, CoverDataPath).

--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -108,6 +108,10 @@ format_array_to_list(Module, CallsPerLineArray, Acc) ->
     [{BinPath, ListOfCallTimes}|Acc].
 
 module_to_lcov(Module, CallsPerLineArray, LCovFile) ->
+    %% lcov file format description can be found here:
+    %%    https://manpages.debian.org/stretch/lcov/geninfo.1.en.html#FILES
+    %% currently this generator creates only the list of execution counts
+    %% for each instrumented line, which is enough for coveralls service.
     io:format(LCovFile, "SF:~s~n", [get_source_path(Module)]),
     CallTimes = array:to_orddict(CallsPerLineArray),
     InstrumentedLines = [{N, C} || {N, C} <- CallTimes, C =/= null],

--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -8,7 +8,8 @@
 -define(PROVIDER, analyze).
 -define(DEPS, [{default, app_discovery}]).
 -define(DESC, "Converts .coverdata files to codecov compatible JSON").
--define(OUT_FILE, "codecov.json").
+-define(JSON_OUT_FILE, "codecov.json").
+-define(LCOV_OUT_FILE, "lcov.info").
 
 %% Public API
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
@@ -19,8 +20,13 @@ init(State) ->
                                     {module, ?MODULE},
                                     {bare, true},
                                     {deps, ?DEPS},
-                                    {example, "rebar3 codecov"},
-                                    {opts, []},
+                                    {example, "rebar3 codecov analyze --lcov --json false"},
+                                    {opts, [
+                                        {lcov, undefined, "lcov", boolean,
+                                         "export data in lcov format (false by default)"},
+                                        {json, undefined, "json", boolean,
+                                         "export data in json format (true by default)"}
+                                    ]},
                                     {short_desc, ?DESC},
                                     {desc, ?DESC}
                                 ]),
@@ -42,8 +48,7 @@ do(State) ->
     code:add_paths(Defaults),
     Files = lists:flatmap(fun get_coverdata_files/1, AppsInfo),
     Data = analyze(Files),
-    rebar_api:info("exporting ~s~n", [?OUT_FILE]),
-    to_json(Data),
+    export(Data, State),
     {ok, State}.
 
 -spec format_error(any()) ->  iolist().
@@ -67,11 +72,31 @@ analyze(Files) ->
             rebar_api:abort("~p~n~p~n~p~n",[Error, Reason, erlang:get_stacktrace()])
     end.
 
-to_json(Data) ->
+export(Data, State) ->
     Mod2Data = lists:foldl(fun add_cover_line_into_array/2, #{}, Data),
+    Formats = export_formats(State),
+    to_json(Mod2Data, Formats),
+    to_lcov(Mod2Data, Formats).
+
+export_formats(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    LCov = proplists:get_value(lcov, Args, false),
+    JSON = proplists:get_value(json, Args, true),
+    #{lcov => LCov, json => JSON}.
+
+to_json(Mod2Data, #{json := true}) ->
+    rebar_api:info("exporting ~s~n", [?JSON_OUT_FILE]),
     JSON = maps:fold(fun format_array_to_list/3, [], Mod2Data),
     Binary = jiffy:encode(#{<<"coverage">> => {JSON}}),
-    file:write_file(?OUT_FILE, Binary).
+    file:write_file(?JSON_OUT_FILE, Binary);
+to_json(_, _) -> ok.
+
+to_lcov(Mod2Data, #{lcov := true}) ->
+    rebar_api:info("exporting ~s~n", [?LCOV_OUT_FILE]),
+    {ok, LCovFile} = file:open(?LCOV_OUT_FILE, [write]),
+    maps:fold(fun module_to_lcov/3, LCovFile, Mod2Data),
+    file:close(LCovFile);
+to_lcov(_, _) -> ok.
 
 add_cover_line_into_array({{Module, Line}, CallTimes}, Acc) ->
     CallsPerLineArray = maps:get(Module, Acc, array:new({default, null})),
@@ -81,6 +106,17 @@ format_array_to_list(Module, CallsPerLineArray, Acc) ->
     ListOfCallTimes = array:to_list(CallsPerLineArray),
     BinPath = list_to_binary(get_source_path(Module)),
     [{BinPath, ListOfCallTimes}|Acc].
+
+module_to_lcov(Module, CallsPerLineArray, LCovFile) ->
+    io:format(LCovFile, "SF:~s~n", [get_source_path(Module)]),
+    CallTimes = array:to_orddict(CallsPerLineArray),
+    InstrumentedLines = [{N, C} || {N, C} <- CallTimes, C =/= null],
+    ExecutedLines = [{N, C} || {N, C} <- InstrumentedLines, C > 0],
+    [io:format(LCovFile, "DA:~p,~p~n", [N, C]) || {N, C} <- InstrumentedLines],
+    io:format(LCovFile, "LH:~p~n", [length(ExecutedLines)]),
+    io:format(LCovFile, "LF:~p~n", [length(InstrumentedLines)]),
+    io:format(LCovFile, "end_of_record~n", []),
+    LCovFile.
 
 get_source_path(Module) when is_atom(Module) ->
     Name = atom_to_list(Module)++".erl",


### PR DESCRIPTION
adding optional generation of lcov.info file, it can be used for coverage reporting to coveralls using [GH action](https://github.com/marketplace/actions/coveralls-github-action)