### PR TITLE
Do not include an empty filename into the report

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,3 +3,5 @@
 {deps, [
         {jsone, "1.8.0"}
        ]}.
+
+{project_plugins, [rebar3_hex]}.

--- a/src/rebar3_codecov_prv.erl
+++ b/src/rebar3_codecov_prv.erl
@@ -128,23 +128,23 @@ get_source_path(Module, SrcDirs) when is_atom(Module) ->
     Name = atom_to_list(Module)++".erl",
     try find_file(Name, SrcDirs) of
         [P] -> P;
+        [] ->
+            rebar_api:warn("Failed to find module path for ~p~n", [Module]),
+            Name;
         Candidates ->
-            Issue = io_lib:format("Several candidates are found for module ~p~n ~p~n",
-                                  [Module, Candidates]),
-            rebar_api:warn("~s~n", [Issue]),
-            ""
+            rebar_api:warn("Several candidates are found for module ~p. Candidates=~p~n",
+                           [Module, Candidates]),
+            Name
     catch
         Error:Reason:Stacktrace ->
-            Issue = io_lib:format("Failed to calculate the source path of module ~p~n
-                                     falling back to ~s", [Module, Name]),
-            rebar_api:warn("~s~n~p~n~p~n~p~n", [Issue, Error, Reason, Stacktrace]),
+            rebar_api:warn("Failed to calculate the source path of module ~p~n ~p~n"
+                           "falling back to ~s", [Module, {Error, Reason, Stacktrace}, Name]),
             Name
     end.
 
 find_file(Name, []) ->
-    Issue = io_lib:format("Failed to find the file location ~p~n", [Name]),
-    rebar_api:warn("~s~n", [Issue]),
-    "";
+    rebar_api:warn("Failed to find the file location ~p~n", [Name]),
+    [];
 find_file(Name, [SrcDir | SrcDirs]) ->
     case filelib:wildcard([filename:join([SrcDir, "**/", Name])]) of
         [] ->


### PR DESCRIPTION
Addresses "MIM-2266 rebar3_codecov sometimes puts empty filenames into codecov.json".

Do not include an empty filename into the report.
Empty-files crash codecov analysis.

Use `Module ++ ".erl"` instead, codecov handles not-found files gracefully. Also, could do something like `"not_found/strange_module.erl"` directory, but not an empty file. And `not_found` is easy to grep. Now we can grep for `""`, but it does not tell us the filename, we need to go and check the circle ci task output.

Example of the bad upload with `Unknown error` could be found there: https://app.codecov.io/github/esl/MongooseIM/commit/46e27800e08ba3fca804c65a1d02684bfc6aff87